### PR TITLE
Numerical constraint language

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,20 +6,20 @@ lazy val root = (project in file(".")).
       // Scalac
       scalacOptions ++= Seq(
         "-language:implicitConversions",
-        "-Xlint",
-        "-Xfuture", // future language features
-        //"-Xfatal-warnings", // fail on warnings
         "-encoding", "UTF-8", // check encoding
         "-feature", // warn on features that should be imported explicitly
         "-explaintypes", // explain type errors in more detail
         "-deprecation", // warn on deprecated APIs
         "-unchecked", // detailed erasure warnings
-        "-Ywarn-adapted-args", // warn if an argument list is modified to match the receiver
+        "-Xfuture", // future language features
+        //"-Xfatal-warnings", // fail on warnings
+        //"-Xlint",
+        //"-Ywarn-adapted-args", // warn if an argument list is modified to match the receiver
+        //"-Ywarn-numeric-widen", // warn when numerics are widened
         "-Ywarn-inaccessible", // warn about inaccessible types in method signatures
         "-Ywarn-infer-any", // warn when a type argument is inferred to be `Any`
         "-Ywarn-nullary-override", // warn when non-nullary `def f()' overrides nullary `def f'
         "-Ywarn-nullary-unit", // warn when nullary methods return Unit
-        "-Ywarn-numeric-widen", // warn when numerics are widened
         "-Ywarn-unused", // warn when local and private vals, vars, defs, and types are unused
         "-Ywarn-unused-import", // warn when imports are unused
         "-Ywarn-value-discard" // warn when non-Unit expression results are unused

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/Parser.scala
@@ -5,24 +5,40 @@ import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpPa
 
 /** Parse into the arithmetic sub-language.
   *
+  * Relies on [[edu.colorado.plv.cuanto.jsy.common.OpParserLike]] to parse unary and binary expressions.
+  *
+  * The atoms are floating pointer literals:
+  *
+  * $arithmeticOpatom
+  *
+  * The unary and binary operators are negation, plus, minus, times,
+  * and divide:
+  *
+  * $arithmeticUop
+  *
+  * $arithmeticBop
+  *
+  * @define arithmeticOpatom ''opatom'' ::= ''float''
+  * @define arithmeticUop ''uop'' ::= '-'
+  * @define arithmeticBop ''bop'' ::= '+' | '-' | '*' | '/'
   * @author Bor-Yuh Evan Chang
   */
 trait ParserLike extends OpParserLike with JsyParserLike {
-  /** ''opatom'' ::= ''float'' */
+  /** $arithmeticOpatom */
   abstract override def opatom: Parser[Expr] =
     positioned {
       floatingPointNumber ^^ (s => N(s.toDouble))
     } |
     super.opatom
 
-  /** ''uop'' ::= '-' */
+  /** $arithmeticUop */
   abstract override def uop: Parser[Uop] =
     "-" ^^ { _ => Neg } |
     super.uop
 
   /** Precedence: { '+', '-' } < { '*', '/' }.
     *
-    * ''bop'' ::= '+' | '-' | '*' | '/'
+    * $arithmeticBop
     */
   lazy val arithmeticBop: OpPrecedence = List(
       /* lowest */
@@ -32,7 +48,11 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   )
 }
 
-/** The parser for just this arithmetic sub-language. */
+/** The parser for just this arithmetic sub-language.
+  *
+  * @see [[ParserLike]]
+  * @author Bor-Yuh Evan Chang
+  */
 object Parser extends UnitOpParser with ParserLike {
   override def start: Parser[Expr] = expr
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/Parser.scala
@@ -1,40 +1,47 @@
 package edu.colorado.plv.cuanto.jsy
 package arithmetic
 
-import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike}
+import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpParser}
 
 /** Parse into the arithmetic sub-language.
   *
   * @author Bor-Yuh Evan Chang
   */
-object Parser extends OpParserLike with JsyParserLike {
+trait ParserLike extends OpParserLike with JsyParserLike {
+  /** ''opatom'' ::= ''float'' */
+  abstract override def opatom: Parser[Expr] =
+    positioned {
+      floatingPointNumber ^^ (s => N(s.toDouble))
+    } |
+    super.opatom
+
+  /** ''uop'' ::= '-' */
+  abstract override def uop: Parser[Uop] =
+    "-" ^^ { _ => Neg } |
+    super.uop
+
+  /** Precedence: { '+', '-' } < { '*', '/' }.
+    *
+    * ''bop'' ::= '+' | '-' | '*' | '/'
+    */
+  lazy val arithmeticBop: OpPrecedence = List(
+      /* lowest */
+      List("+" -> Plus, "-" -> Minus),
+      List("*" -> Times, "/" -> Div)
+      /* highest */
+  )
+}
+
+/** The parser for just this arithmetic sub-language */
+object Parser extends UnitOpParser with ParserLike {
   override def start: Parser[Expr] = expr
 
   /** Parser for expressions ''expr'': [[Expr]].
     *
-    * ''expr'' ::=
-    *
+    * ''expr'' ::= ''binary''
     */
-  def expr: Parser[Expr] = binary
+  override def expr: Parser[Expr] = binary
 
-  /** ''atom'' ::= ''float'' */
-  def opatom: Parser[Expr] =
-    positioned {
-      floatingPointNumber ^^ (s => N(s.toDouble))
-    }
-
-  /** ''uop'' ::= '-' */
-  def uop: Parser[Uop] =
-    "-" ^^ { _ => Neg }
-
-  /** Define precedence of left-associative binary operators.
-    *
-    * ''bop'' ::= '+' | '-' | '*' | '/'
-    */
-  lazy val bop: OpPrecedence = List(
-    /* lowest */
-    List("+" -> Plus, "-" -> Minus),
-    List("*" -> Times, "/" -> Div)
-    /* highest */
-  )
+  /** Define precedence of left-associative binary operators. */
+  override lazy val bop: OpPrecedence = arithmeticBop
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/Parser.scala
@@ -32,7 +32,7 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   )
 }
 
-/** The parser for just this arithmetic sub-language */
+/** The parser for just this arithmetic sub-language. */
 object Parser extends UnitOpParser with ParserLike {
   override def start: Parser[Expr] = expr
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/implicits.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/implicits.scala
@@ -8,7 +8,7 @@ import edu.colorado.plv.cuanto.parsing
   */
 object implicits {
 
-  /** Effectful: parses a [[String]] into an [[Expr]].
+  /** Effectful: parses a string into an [[edu.colorado.plv.cuanto.jsy.Expr]].
     *
     * @see [[Parser]].parse for the interface that returns a [[scala.util.Try]].
     * @throws parsing.SyntaxError when not syntactically valid.

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/implicits.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/implicits.scala
@@ -1,6 +1,8 @@
 package edu.colorado.plv.cuanto.jsy
 package arithmetic
 
+import edu.colorado.plv.cuanto.parsing
+
 /**
   * @author Bor-Yuh Evan Chang
   */
@@ -8,8 +10,10 @@ object implicits {
 
   /** Effectful: parses a [[String]] into an [[Expr]].
     *
-    * @throws [[edu.colorado.plv.cuanto.parsing.SyntaxError]]
+    * @see [[Parser]].parse for the interface that returns a [[scala.util.Try]].
+    * @throws parsing.SyntaxError when not syntactically valid.
     */
+  @throws(classOf[parsing.SyntaxError])
   implicit def stringToExpr(s: String): Expr =
     Parser.parse(s).get
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/package.scala
@@ -4,7 +4,7 @@ package edu.colorado.plv.cuanto.jsy
   *
   * @author Bor-Yuh Evan Chang
   */
-package object arithmetic {
+package arithmetic {
 
   /* Literals and values. */
 
@@ -27,6 +27,10 @@ package object arithmetic {
 
   /** Div ''bop'' ::= `/`. */
   case object Div extends Bop
+
+}
+
+package object arithmetic {
 
   /** Define values. */
   def isValue(e: Expr): Boolean = e match {

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
@@ -35,9 +35,7 @@ object Parser extends OpParserLike with JsyParserLike {
   lazy val bop: OpPrecedence = List(
     /* lowest */
     List("||" -> Or),
-    List("&&" -> And),
-    List("===" -> Eq, "!==" -> Ne),
-    List("<" -> Lt, "<=" -> Le, ">" -> Gt, ">=" -> Ge)
+    List("&&" -> And)
     /* highest */
   )
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
@@ -35,7 +35,7 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   )
 }
 
-/** The parser for just this arithmetic sub-language */
+/** The parser for just this boolean sub-language */
 object Parser extends UnitOpParser with ParserLike {
   override def start: Parser[Expr] = expr
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
@@ -5,12 +5,27 @@ import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpPa
 
 /** Parse into the boolean sub-language.
   *
+  * Relies on [[edu.colorado.plv.cuanto.jsy.common.OpParserLike]] to parse unary and binary expressions.
+  *
+  * The atoms are `true` and `false`
+  *
+  * $booleanOpatom
+  *
+  * The unary and binary operators are negation, or, and and:
+  *
+  * $booleanUop
+  *
+  * $booleanBop
+  *
+  * @define booleanOpatom ''opatom'' ::= `true` | `false`
+  * @define booleanUop '''uop'' ::= `!``
+  * @define booleanBop ''bop'' ::= `||` | `&&`
   * @author Bor-Yuh Evan Chang
   */
 trait ParserLike extends OpParserLike with JsyParserLike {
   override def start: Parser[Expr] = expr
 
-  /** ''atom'' ::= ''float'' */
+  /** $booleanOpatom */
   abstract override def opatom: Parser[Expr] =
     positioned {
       "true" ^^^ B(true) |
@@ -18,14 +33,14 @@ trait ParserLike extends OpParserLike with JsyParserLike {
     } |
     super.opatom
 
-  /** ''uop'' ::= '-' */
+  /** $booleanUop */
   abstract override def uop: Parser[Uop] =
     "!" ^^ { _ => Not } |
     super.uop
 
-  /** Precedence: { '||' } < { '&&' }.
+  /** Precedence: { `||` } < { `&&` }.
     *
-    * ''bop'' ::= '\\' | '&&'
+    * $booleanBop
     */
   lazy val booleanBop: OpPrecedence = List(
     /* lowest */
@@ -35,7 +50,11 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   )
 }
 
-/** The parser for just this boolean sub-language */
+/** The parser for just this boolean sub-language
+  *
+  * @see [[ParserLike]]
+  * @author Bor-Yuh Evan Chang
+  */
 object Parser extends UnitOpParser with ParserLike {
   override def start: Parser[Expr] = expr
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/package.scala
@@ -4,7 +4,7 @@ package edu.colorado.plv.cuanto.jsy
   *
   * @author Bor-Yuh Evan Chang
   */
-package object boolean {
+package boolean {
 
   /* Literals and Values */
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/package.scala
@@ -25,19 +25,6 @@ package object boolean {
   /** Or ''uop'' ::= `||`. */
   case object Or extends Bop
 
-  /** Equal ''bop'' ::= `==`. */
-  case object Eq extends Bop
-  /** Not equal ''bop'' ::= `!=`. */
-  case object Ne extends Bop
-  /** Less than or equal ''bop'' ::= `<=`. */
-  case object Le extends Bop
-  /** Less than ''bop'' ::= `<`. */
-  case object Lt extends Bop
-  /** Greater than or equal ''bop'' ::= `>=`. */
-  case object Ge extends Bop
-  /** Greater than ''bop'' ::= `>`. */
-  case object Gt extends Bop
-
   /** Elimination: if-then-else ''e'' ::= ''e,,1,,'' ? ''e,,2,,'' : ''e,,3,,''. */
   case class If(e1: Expr, e2: Expr, e3: Expr) extends Expr
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/JsyParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/JsyParserLike.scala
@@ -1,18 +1,15 @@
 package edu.colorado.plv.cuanto.jsy
+package common
 
 import edu.colorado.plv.cuanto.parsing.{ParserLike, RichParsers}
 
 import scala.util.parsing.combinator.JavaTokenParsers
 import scala.util.parsing.input.Reader
 
-/**
+/** Trait for a JavaScripty parser.
+  *
   * @author Bor-Yuh Evan Chang
   */
-package object common {
-
-  /** Trait for a JavaScripty parser. */
-  trait JsyParserLike extends JavaTokenParsers with RichParsers with ParserLike[Expr] {
-    override def scan(in: Reader[Char]): Input = in
-  }
-
+trait JsyParserLike extends JavaTokenParsers with RichParsers with ParserLike[Expr] {
+  override def scan(in: Reader[Char]): Input = in
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/JsyParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/JsyParserLike.scala
@@ -6,7 +6,11 @@ import edu.colorado.plv.cuanto.parsing.{ParserLike, RichParsers}
 import scala.util.parsing.combinator.JavaTokenParsers
 import scala.util.parsing.input.Reader
 
-/** Trait for a JavaScripty parser.
+/** Common trait for a JavaScripty parser.
+  *
+  * Mixes [[scala.util.parsing.combinator.JavaTokenParsers]] for basic
+  * tokens (e.g., identifiers, numbers) with some utilities in
+  * [[RichParsers]] and a top-level interface in [[ParserLike]].
   *
   * @author Bor-Yuh Evan Chang
   */

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
@@ -45,9 +45,9 @@ trait OpParserLike extends RegexParsers with RichParsers {
       }
       def level(ops: List[(String, Bop)]): Parser[(Expr, Expr) => Expr] = {
         val op1 :: t = ops
-        (binaryCase(op1) /: t) { (acc, op) => acc | binaryCase(op) }
+        t.foldLeft(binaryCase(op1)) { (acc, op) => acc | binaryCase(op) }
       }
-      (ops :\ unary) { (lops, acc) => acc * level(lops) }
+      ops.foldRight(unary) { (lops, acc) => acc * level(lops) }
     }
     binaryOps(bop)
   }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
@@ -52,10 +52,10 @@ import scala.util.parsing.combinator.RegexParsers
   *       }
   *     override def uop: Parser[Uop] =
   *       "-" ^^ { _ => Neg }
-  *     override def bop: OpPrecedence = List(
+  *     override def bop: OpPrecedence = Seq(
   *       /* lowest */
-  *       List("+" -> Plus, "-" -> Minus),
-  *       List("*" -> Times, "/" -> Div)
+  *       Seq("+" -> Plus, "-" -> Minus),
+  *       Seq("*" -> Times, "/" -> Div)
   *       /* highest */
   *     )
   *   }
@@ -74,7 +74,7 @@ trait OpParserLike extends RegexParsers with RichParsers {
   /** Define unary operators. */
   def uop: Parser[Uop]
 
-  /** Type alias for list precedence of binary operators.
+  /** Type alias for the list defining the precedence of binary operators.
     *
     * @see [[bop]] for defining the precedence of binary operators.
     */

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
@@ -7,6 +7,61 @@ import scala.util.parsing.combinator.RegexParsers
 
 /** Parser components that handle unary and binary operators.
   *
+  * This trait implements standard non-terminals for an expression language
+  * with unary and binary operators.
+  *
+  * ==Abstract Syntax==
+  *
+  * This trait implements a parser for the following abstract syntax
+  * consisting of atoms, unary, and binary expressions.
+  *
+  * ''expr'' ::= ''atom'' | ''uop'' ''expr'' | ''expr'' ''bop'' ''expr''
+  *
+  * ==Concrete Syntax==
+  *
+  * Specifically, it implements a parser given a specification for the atoms,
+  * unary, and binary operators for the following concrete syntax:
+  *
+  * ''binary,,1,,'' ::= ''binary,,2,,'' { ''bop,,1,,'' ''binary,,2,,'' }
+  *
+  *  ...
+  *
+  * ''binary,,n,,'' ::= ''unary'' { ''bop,,n,,'' ''unary'' }
+  *
+  * ''unary'' ::= ''uop'' ''unary'' | ''atom''
+  *
+  * ''atom'' ::= ''opatom'' | `(` ''expr'' `)`
+  *
+  * The { α } is in the meta-language to indicate 0-or-more α's (i.e., EBNF).
+  *
+  * The ''expr'', ''opatom'', and ''uop'' symbols are specified by defining
+  * [[scala.util.parsing.combinator.Parsers#Parser]]s.
+  *
+  * The ''bop'' symbols is specified by defining `bop`, which should be a
+  * list of list of concrete-abstract syntax pairs. The outer list specifies
+  * the precedence levels from lowest to highest, while the inner list are
+  * the operators at the same level. All operators are treated as
+  * left-associative.
+  *
+  * @example {{{
+  *
+  *   trait ArithmeticParser extends OpParserLike with JavaTokenParsers {
+  *     override def opatom: Parser[Expr] =
+  *       positioned {
+  *         floatingPointNumber ^^ (s => N(s.toDouble))
+  *       }
+  *     override def uop: Parser[Uop] =
+  *       "-" ^^ { _ => Neg }
+  *     override def bop: OpPrecedence = List(
+  *       /* lowest */
+  *       List("+" -> Plus, "-" -> Minus),
+  *       List("*" -> Times, "/" -> Div)
+  *       /* highest */
+  *     )
+  *   }
+  *
+  * }}}
+  *
   * @author Bor-Yuh Evan Chang
   */
 trait OpParserLike extends RegexParsers with RichParsers {
@@ -19,31 +74,27 @@ trait OpParserLike extends RegexParsers with RichParsers {
   /** Define unary operators. */
   def uop: Parser[Uop]
 
-  /** Precedence of binary operators.
+  /** Type alias for list precedence of binary operators.
+    *
+    * @see [[bop]] for defining the precedence of binary operators.
+    */
+  type OpPrecedence = Seq[Seq[(String,Bop)]]
+
+  /** Define precedence of left-associative binary operators.
     *
     * Specified from lowest to highest, consisting of pairs of
     * concrete-abstract syntax.
     */
-  type OpPrecedence = List[List[(String,Bop)]]
-
-  /** Define precedence of left-associative binary operators. */
   val bop: OpPrecedence
 
-  /** Parser for binary expressions.
-    *
-    * ''binary,,1,,'' ::= ''binary,,2,,'' { ''bop,,1,,'' ''binary,,2,,'' }
-    *
-    * ...
-    *
-    * ''binary,,n,,'' ::= ''unary'' { ''bop,,n,,'' ''unary'' }
-    */
+  /** Parser for binary expressions. */
   def binary: Parser[Expr] = {
     def binaryOps(ops: OpPrecedence): Parser[Expr] = {
       def binaryCase(opsyn: (String, Bop)): Parser[(Expr, Expr) => Expr] = {
         val (csyn, asyn) = opsyn
         withpos(csyn) ^^ { case (pos, _) => (e1: Expr, e2: Expr) => Binary(asyn, e1, e2) setPos pos }
       }
-      def level(ops: List[(String, Bop)]): Parser[(Expr, Expr) => Expr] = {
+      def level(ops: Seq[(String, Bop)]): Parser[(Expr, Expr) => Expr] = {
         val op1 :: t = ops
         t.foldLeft(binaryCase(op1)) { (acc, op) => acc | binaryCase(op) }
       }
@@ -52,17 +103,14 @@ trait OpParserLike extends RegexParsers with RichParsers {
     binaryOps(bop)
   }
 
-  /** Parser for unary expressions.
-    *
-    * ''unary'' ::= ''uop'' ''unary'' | ''atom''
-    */
+  /** Parser for unary expressions. */
   def unary: Parser[Expr] =
     positioned {
       uop ~ unary ^^ { case op ~ e => Unary(op, e) }
     } |
     atom
 
-  /** ''atom'' ::= ''opatom'' | '(' ''expr'' ')' */
+  /** Parser for atoms. */
   def atom: Parser[Expr] =
     opatom |
     "(" ~> expr <~ ")" |

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
@@ -3,13 +3,13 @@ package edu.colorado.plv.cuanto.jsy.common
 import edu.colorado.plv.cuanto.jsy._
 import edu.colorado.plv.cuanto.parsing.RichParsers
 
-import scala.util.parsing.combinator.{Parsers, RegexParsers}
+import scala.util.parsing.combinator.RegexParsers
 
 /** Parser components that handle unary and binary operators.
   *
   * @author Bor-Yuh Evan Chang
   */
-trait OpParserLike { _: RichParsers with RegexParsers with Parsers =>
+trait OpParserLike extends RegexParsers with RichParsers {
   /** Define expressions. */
   def expr: Parser[Expr]
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/UnitOpParser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/UnitOpParser.scala
@@ -4,8 +4,8 @@ package common
 import edu.colorado.plv.cuanto.parsing.RichParsers
 import scala.util.parsing.combinator.{Parsers, RegexParsers}
 
-/** Define a unit [[OpParserLike]] that is
-  * [[Parsers]].failure on everything.
+/** Define a unit [[edu.colorado.plv.cuanto.jsy.common.OpParserLike]] that is
+  * [[scala.util.parsing.combinator.Parsers]].failure on everything.
   *
   * @author Bor-Yuh Evan Chang
   */

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/UnitOpParser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/UnitOpParser.scala
@@ -1,0 +1,14 @@
+package edu.colorado.plv.cuanto.jsy
+package common
+
+import edu.colorado.plv.cuanto.parsing.RichParsers
+import scala.util.parsing.combinator.{Parsers, RegexParsers}
+
+/** Define a unit [[OpParserLike]] that is [[Parsers.failure]] on everything.
+  *
+  * @author Bor-Yuh Evan Chang
+  */
+trait UnitOpParser extends OpParserLike { _: RichParsers with RegexParsers with Parsers =>
+  override def opatom: Parser[Expr] = failure("expected opatom")
+  override def uop: Parser[Uop] = failure("expected uop")
+}

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/UnitOpParser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/UnitOpParser.scala
@@ -4,7 +4,8 @@ package common
 import edu.colorado.plv.cuanto.parsing.RichParsers
 import scala.util.parsing.combinator.{Parsers, RegexParsers}
 
-/** Define a unit [[OpParserLike]] that is [[Parsers.failure]] on everything.
+/** Define a unit [[OpParserLike]] that is
+  * [[Parsers]].failure on everything.
   *
   * @author Bor-Yuh Evan Chang
   */

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/package.scala
@@ -2,7 +2,7 @@ package edu.colorado.plv.cuanto.jsy
 
 import edu.colorado.plv.cuanto.parsing.{ParserLike, RichParsers}
 
-import scala.util.parsing.combinator.{JavaTokenParsers, Parsers}
+import scala.util.parsing.combinator.JavaTokenParsers
 import scala.util.parsing.input.Reader
 
 /**

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/Parser.scala
@@ -1,7 +1,7 @@
 package edu.colorado.plv.cuanto.jsy
 package numerical
 
-import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike}
+import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpParser}
 
 /** Parse into the numerical sub-language.
   *
@@ -11,10 +11,24 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   lazy val comparisonBop: OpPrecedence = List(
     /* lowest */
     List("===" -> Eq, "!==" -> Ne),
-    List("<" -> Lt, "<=" -> Le, ">" -> Gt, ">=" -> Ge)
+    List("<=" -> Le, "<" -> Lt, ">=" -> Ge, ">" -> Gt)
     /* highest */
   )
 }
 
-/** The parser for just this arithmetic sub-language. */
-object Parser
+/** The parser for just this numerical sub-language. */
+object Parser extends UnitOpParser with ParserLike with boolean.ParserLike with arithmetic.ParserLike {
+  override def start: Parser[Expr] = expr
+
+  /** Parser for expressions ''expr'': [[Expr]].
+    *
+    * ''expr'' ::= ''binary''
+    */
+  override def expr: Parser[Expr] = binary
+
+  /** Define precedence of left-associative binary operators. */
+  override lazy val bop: OpPrecedence =
+    /* lowest */
+    booleanBop ++ (comparisonBop ++ arithmeticBop)
+    /* highest */
+}

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/Parser.scala
@@ -3,7 +3,10 @@ package numerical
 
 import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpParser}
 
-/** Parse into the numerical sub-language.
+/** Extend with the numerical sub-language.
+  *
+  * The numerical sub-language simply adds comparison operators:
+  * `===`, `!==`, `<=`, `<`, `>=`, and `>`.
   *
   * @author Bor-Yuh Evan Chang
   */
@@ -16,7 +19,13 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   )
 }
 
-/** The parser for just this numerical sub-language. */
+/** The parser for just this numerical sub-language.
+  *
+  * Mixes the [[arithmetic.ParserLike]] sub-language with the
+  * [[boolean.ParserLike]] sub-language with comparison operators.
+  *
+  * @author Bor-Yuh Evan Chang
+  */
 object Parser extends UnitOpParser with ParserLike with boolean.ParserLike with arithmetic.ParserLike {
   override def start: Parser[Expr] = expr
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/Parser.scala
@@ -1,0 +1,20 @@
+package edu.colorado.plv.cuanto.jsy
+package numerical
+
+import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike}
+
+/** Parse into the numerical sub-language.
+  *
+  * @author Bor-Yuh Evan Chang
+  */
+trait ParserLike extends OpParserLike with JsyParserLike {
+  lazy val comparisonBop: OpPrecedence = List(
+    /* lowest */
+    List("===" -> Eq, "!==" -> Ne),
+    List("<" -> Lt, "<=" -> Le, ">" -> Gt, ">=" -> Ge)
+    /* highest */
+  )
+}
+
+/** The parser for just this arithmetic sub-language. */
+object Parser

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/package.scala
@@ -1,0 +1,24 @@
+package edu.colorado.plv.cuanto.jsy
+
+/** Define a sub-language of numerical constraints.
+  *
+  * Combines [[arithmetic]] and [[boolean]].
+  *
+  * @author Bor-Yuh Evan Chang
+  */
+package object numerical {
+
+  /** Equal ''bop'' ::= `==`. */
+  case object Eq extends Bop
+  /** Not equal ''bop'' ::= `!=`. */
+  case object Ne extends Bop
+  /** Less than or equal ''bop'' ::= `<=`. */
+  case object Le extends Bop
+  /** Less than ''bop'' ::= `<`. */
+  case object Lt extends Bop
+  /** Greater than or equal ''bop'' ::= `>=`. */
+  case object Ge extends Bop
+  /** Greater than ''bop'' ::= `>`. */
+  case object Gt extends Bop
+
+}

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/package.scala
@@ -6,7 +6,7 @@ package edu.colorado.plv.cuanto.jsy
   *
   * @author Bor-Yuh Evan Chang
   */
-package object numerical {
+package numerical {
 
   /** Equal ''bop'' ::= `==`. */
   case object Eq extends Bop

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/package.scala
@@ -5,7 +5,7 @@ import scala.util.parsing.input.Positional
 /**
   * @author Bor-Yuh Evan Chang
   */
-package object jsy {
+package jsy {
 
   /** Expressions ''e''. */
   trait Expr extends Positional

--- a/src/main/scala/edu/colorado/plv/cuanto/parsing/ParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/parsing/ParserLike.scala
@@ -18,7 +18,7 @@ trait ParserLike[+T] { _: Parsers =>
   /** Define the start symbol. */
   def start: Parser[T]
 
-  /** Parse a complete phrase using [[start]]. */
+  /** Parse a complete phrase using `start`. */
   def parse(in: Input, source: String): Try[T] = Try {
     phrase(start)(in) match {
       case Success(t, _) => t
@@ -26,17 +26,17 @@ trait ParserLike[+T] { _: Parsers =>
     }
   }
 
-  /** Parse a complete phrase from `in`: [[java.lang.CharSequence]]. */
+  /** Parse a complete phrase from `in`: [[CharSequence]]. */
   def parse(in: CharSequence): Try[T] =
     parse(scan(new CharSequenceReader(in)), "<string>")
 
-  /** Parse a complete phrase from `in`: [[java.io.InputStream]]. */
+  /** Parse a complete phrase from `in`: [[InputStream]]. */
   def parse(in: InputStream, source: String = "<stream>"): Try[T] = {
     val reader = StreamReader(new InputStreamReader(in))
     parse(scan(reader), source)
   }
 
-  /** Parse a complete phrase from `in`: [[java.io.File]]. */
+  /** Parse a complete phrase from `in`: [[File]]. */
   def parse(in: File): Try[T]  =
     parse(new FileInputStream(in), in.getName)
 

--- a/src/main/scala/edu/colorado/plv/cuanto/parsing/ParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/parsing/ParserLike.scala
@@ -26,17 +26,17 @@ trait ParserLike[+T] { _: Parsers =>
     }
   }
 
-  /** Parse a complete phrase from `in`: [[CharSequence]]. */
+  /** Parse a complete phrase from `in`: [[java.lang.CharSequence]]. */
   def parse(in: CharSequence): Try[T] =
     parse(scan(new CharSequenceReader(in)), "<string>")
 
-  /** Parse a complete phrase from `in`: [[InputStream]]. */
+  /** Parse a complete phrase from `in`: [[java.io.InputStream]]. */
   def parse(in: InputStream, source: String = "<stream>"): Try[T] = {
     val reader = StreamReader(new InputStreamReader(in))
     parse(scan(reader), source)
   }
 
-  /** Parse a complete phrase from `in`: [[File]]. */
+  /** Parse a complete phrase from `in`: [[java.io.File]]. */
   def parse(in: File): Try[T]  =
     parse(new FileInputStream(in), in.getName)
 

--- a/src/main/scala/edu/colorado/plv/cuanto/parsing/RichParsers.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/parsing/RichParsers.scala
@@ -3,7 +3,7 @@ package edu.colorado.plv.cuanto.parsing
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.Position
 
-/** Mix in some utilities for [[Parsers]].
+/** Mix in some utilities for [[scala.util.parsing.combinator.Parsers]].
   *
   * @author Bor-Yuh Evan Chang
   */

--- a/src/main/scala/edu/colorado/plv/cuanto/parsing/RichParsers.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/parsing/RichParsers.scala
@@ -3,7 +3,7 @@ package edu.colorado.plv.cuanto.parsing
 import scala.util.parsing.combinator.Parsers
 import scala.util.parsing.input.Position
 
-/** Mix in some utilities for [[scala.util.parsing.combinator.Parsers]].
+/** Mix in some utilities for [[Parsers]].
   *
   * @author Bor-Yuh Evan Chang
   */

--- a/src/main/scala/edu/colorado/plv/cuanto/parsing/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/parsing/package.scala
@@ -5,7 +5,7 @@ import scala.util.parsing.input.{NoPosition, Position}
 /**
   * @author Bor-Yuh Evan Chang
   */
-package object parsing {
+package parsing {
 
   /** Represent an error with location information. */
   class PositionedError(kind: String, msg: String, source: String, pos: Position) extends Exception {

--- a/src/main/scala/edu/colorado/plv/cuanto/recursing/FixFun.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/recursing/FixFun.scala
@@ -19,7 +19,7 @@ class FixFun[E,R] private(private val gen: (E => R) => PartialFunction[E,R]) ext
   def apply(e: E): R = fun(e)
 
   /** Explicitly lift the partial function potentially failing with
-    * a [[MatchError]]. Does not catch any other exceptions.
+    * a [[scala.MatchError]]. Does not catch any other exceptions.
     */
   def lift: E => Try[R] = { e: E =>
     try { Success(apply(e)) }

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/arithmetic/ArithmeticInterpreterSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/arithmetic/ArithmeticInterpreterSpec.scala
@@ -1,16 +1,15 @@
 package edu.colorado.plv.cuanto.jsy
 package arithmetic
 
-import org.scalatest.{FlatSpec, Matchers}
 import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
 
 /**
   * @author Bor-Yuh Evan Chang
   */
 class ArithmeticInterpreterSpec extends FlatSpec with Matchers with PropertyChecks {
-  import implicits.stringToExpr
   import Interpreter._
-  import syntax._
+  import implicits.stringToExpr
 
   val denoteTests = Table(
     "expression" -> "denotation",

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/numerical/NumericalParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/numerical/NumericalParserSpec.scala
@@ -1,0 +1,37 @@
+package edu.colorado.plv.cuanto.jsy
+package numerical
+
+import edu.colorado.plv.cuanto.jsy.arithmetic._
+import edu.colorado.plv.cuanto.jsy.boolean._
+import edu.colorado.plv.cuanto.jsy.numerical.Parser.parse
+import edu.colorado.plv.cuanto.testing.implicits.tryEquality
+import org.scalatest.prop.PropertyChecks
+import org.scalatest.{FlatSpec, Matchers}
+
+/**
+  * @author Bor-Yuh Evan Chang
+  */
+class NumericalParserSpec extends FlatSpec with Matchers with PropertyChecks {
+
+  behavior of "jsy.numerical.Parser"
+
+  val positives = Table(
+    "concrete" -> "abstract",
+    /* constraints */
+    "true !== false" -> Binary(Ne, B(true), B(false)),
+    "3 <= false" -> Binary(Le, N(3), B(false)),
+    /* mixed */
+    "(2 + 3) === 4" -> Binary(Eq, Binary(Plus, N(2), N(3)), N(4)),
+    "(true && false) !== false" -> Binary(Ne, Binary(And, B(true), B(false)), B(false)),
+    /* precedence */
+    "2 + 3 === 4" -> Binary(Eq, Binary(Plus, N(2), N(3)), N(4)),
+    "true !== 4 < 5" -> Binary(Ne, B(true), Binary(Lt, N(4), N(5)))
+  )
+
+  forAll (positives) { (conc, abs) =>
+    it should s"parse $conc into $abs" in {
+      parse(conc) shouldEqual abs
+    }
+  }
+
+}


### PR DESCRIPTION
Feature: add numerical constraint language that combines arithmetic and boolean.

@bennostein @kyleheadley I am starting this pull request to start talking about the combinator parsing refactoring. For a while, I think I was fighting the design pattern from the scala-parser-combinators library, whereas I think the intended design is to stack traits until instantiating a singleton at the end.