### PR TITLE
Add if-then-else to jsy.boolean

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,13 @@ lazy val root = (project in file(".")).
       scalaVersion := "2.12.1",
       version      := "0.1.0-SNAPSHOT"
     )),
-    
+
+    // Scaladoc
+    scalacOptions in (Compile, doc) ++= Seq(
+      "-groups", // Group similar functions together (based on the @group annotation)
+      "-implicits" // Document members inherited by implicit conversions.
+    ),
+
     // Puts Scaladoc output in `target/site/api/latest`
     siteSubdirName in SiteScaladoc := "api/latest",
     

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/package.scala
@@ -9,7 +9,7 @@ package arithmetic {
   /* Literals and values. */
 
   /** Numbers ''e'' ::= ''n''. */
-  case class N(n: Double) extends Expr
+  case class N(n: Double) extends Val
 
   /* Unary and binary operators. */
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
@@ -18,7 +18,7 @@ import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpPa
   * $booleanBop
   *
   * @define booleanOpatom ''opatom'' ::= `true` | `false`
-  * @define booleanUop '''uop'' ::= `!``
+  * @define booleanUop ''uop'' ::= `!`
   * @define booleanBop ''bop'' ::= `||` | `&&`
   * @author Bor-Yuh Evan Chang
   */

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
@@ -7,7 +7,7 @@ import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpPa
   *
   * Relies on [[edu.colorado.plv.cuanto.jsy.common.OpParserLike]] to parse unary and binary expressions.
   *
-  * The atoms are `true` and `false`
+  * The atoms are `true`, `false`, and ''ifthenelse''.
   *
   * $booleanOpatom
   *
@@ -17,23 +17,48 @@ import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpPa
   *
   * $booleanBop
   *
-  * @define booleanOpatom ''opatom'' ::= `true` | `false`
+  * The ternary ''e,,1,,'' `?` ''e,,2,,'' `:` ''e,,3,,'' has the lowest precedence.
+  *
+  * @define booleanIteop ''iteop'' ::=  ''binary'' `?` ''expr'' `:` ''itesub''
+  * @define booleanIfthenelse ''ifthenelse'' ::= `if` ''e'' `then` ''e'' `else` ''itesub''
+  * @define booleanOpatom ''opatom'' ::= `true` | `false` | `ifthenelse`
   * @define booleanUop ''uop'' ::= `!`
   * @define booleanBop ''bop'' ::= `||` | `&&`
+  *
   * @author Bor-Yuh Evan Chang
   */
 trait ParserLike extends OpParserLike with JsyParserLike {
+  /** Parameter: define the non-terminal for the sub-expressions
+    * of the if-then-else expression, that is,
+    *
+    *   - $booleanIteop
+    *   - $booleanIfthenelse
+    */
+  def itesub: Parser[Expr]
+
+  def iteop: Parser[Expr] =
+    binary ~ opt(withpos(("?" ~> expr) ~ (":" ~> itesub))) ^^ {
+      case e1 ~ None => e1
+      case e1 ~ Some((pos, e2 ~ e3)) => If(e1, e2, e3) setPos pos
+    }
+
   /** $booleanOpatom */
   abstract override def opatom: Parser[Expr] =
     positioned {
       "true" ^^^ B(true) |
-      "false" ^^^ B(false)
+      "false" ^^^ B(false) |
+      ifthenelse
     } |
     super.opatom
 
+  def ifthenelse: Parser[Expr] =
+    ("if" ~> parenthesized) ~ expr ~ ("else" ~> itesub) ^^ {
+      case e1 ~ e2 ~ e3 => If(e1, e2, e3)
+    }
+
   /** $booleanUop */
   abstract override def uop: Parser[Uop] =
-    "!" ^^ { _ => Not } |
+    "!" ^^^ Not |
     super.uop
 
   /** Precedence: { `||` } < { `&&` }.
@@ -48,20 +73,14 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   )
 }
 
-/** The parser for just this boolean sub-language
+/** The parser for just this boolean sub-language.
   *
   * @see [[ParserLike]]
   * @author Bor-Yuh Evan Chang
   */
 object Parser extends UnitOpParser with ParserLike {
   override def start: Parser[Expr] = expr
-
-  /** Parser for expressions ''expr'': [[Expr]].
-    *
-    * ''expr'' ::= ''binary''
-    */
-  override def expr: Parser[Expr] = binary
-
-  /** Define precedence of left-associative binary operators. */
+  override def expr: Parser[Expr] = iteop
+  override def itesub: Parser[Expr] = iteop
   override lazy val bop: OpPrecedence = booleanBop
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
@@ -23,8 +23,6 @@ import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpPa
   * @author Bor-Yuh Evan Chang
   */
 trait ParserLike extends OpParserLike with JsyParserLike {
-  override def start: Parser[Expr] = expr
-
   /** $booleanOpatom */
   abstract override def opatom: Parser[Expr] =
     positioned {

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/package.scala
@@ -1,32 +1,37 @@
 package edu.colorado.plv.cuanto.jsy
 
-/** Define an boolean sub-language.
-  *
-  * @author Bor-Yuh Evan Chang
-  */
 package boolean {
 
   /* Literals and Values */
 
-  /** Booleans ''e'' ::= ''b''. */
-  case class B(b: Boolean) extends Expr
+  /** @group Abstract Syntax Nodes */
+  case class B(b: Boolean) extends Val
 
   /* Operators */
 
-  /** Unary operators ''uop''. */
-
-  /** Not ''uop'' ::= `!`. */
+  /** @group Abstract Syntax Nodes */
   case object Not extends Uop
-
-  /** Binary operators ''bop''. */
-
-  /** And ''uop'' ::= `&&`. */
+  /** @group Abstract Syntax Nodes */
   case object And extends Bop
-  /** Or ''uop'' ::= `||`. */
+  /** @group Abstract Syntax Nodes */
   case object Or extends Bop
-
-  /** Elimination: ''e'' ::= ''e,,1,,'' ? ''e,,2,,'' : ''e,,3,,''
-    * | `if` `(e,,1,,)` ''e,,2,,'' `else` ''e,,3,,'' . */
+  /** @group Abstract Syntax Nodes */
   case class If(e1: Expr, e2: Expr, e3: Expr) extends Expr
 
 }
+
+/** Define the Boolean sub-language.
+  *
+  * This package defines the abstract syntax nodes for Boolean expressions.
+  *
+  * ==Abstract Syntax==
+  *
+  *   - ''v'' ::= ''b'' ≡ `B(''b'')`
+  *   - ''uop'' ::= `!` ≡ `Not`
+  *   - ''bop'' ::= `&&` ≡ `And` | `||` ≡ `Or`
+  *   - ''e'' ::=  `if` `(''e,,1,,'')` ''e,,2,,'' `else` ''e,,3,,'' ≡ `If(''e,,1,,'', ''e,,2,,'', ''e,,3,,'')`
+  *   - ''b'' ϵ `Boolean` ::= `true` | `false`
+  *
+  * @author Bor-Yuh Evan Chang
+  */
+package object boolean

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/package.scala
@@ -9,7 +9,7 @@ package boolean {
   /* Literals and Values */
 
   /** Booleans ''e'' ::= ''b''. */
-  case class B(b: Boolean) extends Val
+  case class B(b: Boolean) extends Expr
 
   /* Operators */
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/package.scala
@@ -9,7 +9,7 @@ package boolean {
   /* Literals and Values */
 
   /** Booleans ''e'' ::= ''b''. */
-  case class B(b: Boolean) extends Expr
+  case class B(b: Boolean) extends Val
 
   /* Operators */
 
@@ -25,7 +25,8 @@ package boolean {
   /** Or ''uop'' ::= `||`. */
   case object Or extends Bop
 
-  /** Elimination: if-then-else ''e'' ::= ''e,,1,,'' ? ''e,,2,,'' : ''e,,3,,''. */
+  /** Elimination: ''e'' ::= ''e,,1,,'' ? ''e,,2,,'' : ''e,,3,,''
+    * | `if` `(e,,1,,)` ''e,,2,,'' `else` ''e,,3,,'' . */
   case class If(e1: Expr, e2: Expr, e3: Expr) extends Expr
 
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
@@ -15,22 +15,18 @@ import scala.util.parsing.combinator.RegexParsers
   * This trait implements a parser for the following abstract syntax
   * consisting of atoms, unary, and binary expressions.
   *
-  * ''expr'' ::= ''atom'' | ''uop'' ''expr'' | ''expr'' ''bop'' ''expr''
+  *   - ''expr'' ::= ''atom'' | ''uop'' ''expr'' | ''expr'' ''bop'' ''expr''
   *
   * ==Concrete Syntax==
   *
   * Specifically, it implements a parser given a specification for the atoms,
   * unary, and binary operators for the following concrete syntax:
   *
-  * ''binary,,1,,'' ::= ''binary,,2,,'' { ''bop,,1,,'' ''binary,,2,,'' }
-  *
-  *  ...
-  *
-  * ''binary,,n,,'' ::= ''unary'' { ''bop,,n,,'' ''unary'' }
-  *
-  * ''unary'' ::= ''uop'' ''unary'' | ''atom''
-  *
-  * ''atom'' ::= ''opatom'' | `(` ''expr'' `)`
+  *   - ''binary,,1,,'' ::= ''binary,,2,,'' { ''bop,,1,,'' ''binary,,2,,'' }
+  *   - ...
+  *   - ''binary,,n,,'' ::= ''unary'' { ''bop,,n,,'' ''unary'' }
+  *   - ''unary'' ::= ''uop'' ''unary'' | ''atom''
+  *   - ''atom'' ::= ''opatom'' | `(` ''expr'' `)` | `{` ''expr'' `}`
   *
   * The { α } is in the meta-language to indicate 0-or-more α's (i.e., EBNF).
   *
@@ -65,13 +61,13 @@ import scala.util.parsing.combinator.RegexParsers
   * @author Bor-Yuh Evan Chang
   */
 trait OpParserLike extends RegexParsers with RichParsers {
-  /** Define expressions. */
+  /** Parameter: define expressions. */
   def expr: Parser[Expr]
 
-  /** Define atoms. */
+  /** Parameter: define atoms. */
   def opatom: Parser[Expr]
 
-  /** Define unary operators. */
+  /** Parameter: define unary operators. */
   def uop: Parser[Uop]
 
   /** Type alias for the list defining the precedence of binary operators.
@@ -80,14 +76,17 @@ trait OpParserLike extends RegexParsers with RichParsers {
     */
   type OpPrecedence = Seq[Seq[(String,Bop)]]
 
-  /** Define precedence of left-associative binary operators.
+  /** Parameter: define precedence of left-associative binary operators.
     *
     * Specified from lowest to highest, consisting of pairs of
     * concrete-abstract syntax.
     */
   val bop: OpPrecedence
 
-  /** Parser for binary expressions. */
+  /** Yields a parser for binary expressions with an instantiation for `bop`.
+    *
+    * @see bop
+    */
   def binary: Parser[Expr] = {
     def binaryOps(ops: OpPrecedence): Parser[Expr] = {
       def binaryCase(opsyn: (String, Bop)): Parser[(Expr, Expr) => Expr] = {
@@ -103,16 +102,23 @@ trait OpParserLike extends RegexParsers with RichParsers {
     binaryOps(bop)
   }
 
-  /** Parser for unary expressions. */
+  /** Yields a parser for unary expressions with an instantiation for `uop`
+    *
+    * @see uop
+    */
   def unary: Parser[Expr] =
     positioned {
       uop ~ unary ^^ { case op ~ e => Unary(op, e) }
     } |
     atom
 
-  /** Parser for atoms. */
+  /** Parse parenthesized expressions and delegates to `opatom`.
+    *
+    * @see opatom
+    */
   def atom: Parser[Expr] =
     opatom |
-    "(" ~> expr <~ ")" |
+    "(" ~> expr <~ ")" |         // parentheses
+    "{" ~> expr <~ "}" |         // blocks (just treat them as parentheses)
     failure("expected an atom")
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
@@ -118,7 +118,13 @@ trait OpParserLike extends RegexParsers with RichParsers {
     */
   def atom: Parser[Expr] =
     opatom |
-    "(" ~> expr <~ ")" |         // parentheses
-    "{" ~> expr <~ "}" |         // blocks (just treat them as parentheses)
+    parenthesized |
+    block |
     failure("expected an atom")
+
+  def parenthesized: Parser[Expr] =
+    "(" ~> expr <~ ")"
+
+  def block: Parser[Expr] =
+    "{" ~> expr <~ "}"  // blocks (just treat them as parentheses)
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/Parser.scala
@@ -28,14 +28,8 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   */
 object Parser extends UnitOpParser with ParserLike with boolean.ParserLike with arithmetic.ParserLike {
   override def start: Parser[Expr] = expr
-
-  /** Parser for expressions ''expr'': [[Expr]].
-    *
-    * ''expr'' ::= ''binary''
-    */
-  override def expr: Parser[Expr] = binary
-
-  /** Define precedence of left-associative binary operators. */
+  override def expr: Parser[Expr] = iteop
+  override def itesub: Parser[Expr] = expr
   override lazy val bop: OpPrecedence =
     /* lowest */
     booleanBop ++ (comparisonBop ++ arithmeticBop)

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/package.scala
@@ -7,10 +7,7 @@ package jsy {
   /** Expressions ''e''. */
   trait Expr extends Positional
 
-  /** Unary expressions ''e'' ::= $jsyUnaryProduction . */
   case class Unary(op: Uop, e1: Expr) extends Expr
-
-  /** Binary expressions ''e'' ::= $jsyBinaryProduction. */
   case class Binary(op: Bop, e1: Expr, e2: Expr) extends Expr
 
   /** Unary operators ''uop''. */
@@ -19,7 +16,7 @@ package jsy {
   /** Binary operators ''bop''. */
   trait Bop
 
-  /** Values ''v'' with ''e'' ::= ''v''. */
+  /** Values ''v''. */
   trait Val extends Expr
 
 }
@@ -59,7 +56,7 @@ package jsy {
   * ==Abstract Syntax==
   *
   * As a notation convenience, we write productions with concrete and
-  * abstract syntax using ϵ at the meta-level to separate concrete and
+  * abstract syntax using ≡ at the meta-level to separate concrete and
   * abstract syntax.
   *
   *   - ''e'' ϵ `Expr` ::= ''v''
@@ -69,11 +66,10 @@ package jsy {
   *   - ''bop'' ϵ `Bop`
   *   - ''v'' ϵ `Val`
   *
-  * @define jsyUnaryProduction ''uop'' ''e,,1,,'' ϵ `Unary(''uop'', ''e,,1,,'')`
-  * @define jsyBinaryProduction ''e,,1,,'' ''bop'' ''e,,2,,'' ϵ `Binary(''bop'', ''e,,1,,'', ''e,,2,,'')`
+  * @define jsyUnaryProduction ''uop'' ''e,,1,,'' ≡ `Unary(''uop'', ''e,,1,,'')`
+  * @define jsyBinaryProduction ''e,,1,,'' ''bop'' ''e,,2,,'' ≡ `Binary(''bop'', ''e,,1,,'', ''e,,2,,'')`
   *
   * @author Bor-Yuh Evan Chang
   */
 package object jsy
-
 

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/package.scala
@@ -2,18 +2,15 @@ package edu.colorado.plv.cuanto
 
 import scala.util.parsing.input.Positional
 
-/**
-  * @author Bor-Yuh Evan Chang
-  */
 package jsy {
 
   /** Expressions ''e''. */
   trait Expr extends Positional
 
-  /** Unary expressions ''e'' ::= ''uop'' ''e,,1,,''. */
+  /** Unary expressions ''e'' ::= $jsyUnaryProduction . */
   case class Unary(op: Uop, e1: Expr) extends Expr
 
-  /** Binary expressions ''e'' ::= ''e,,1,,'' ''bop'' ''e,,2,,''. */
+  /** Binary expressions ''e'' ::= $jsyBinaryProduction. */
   case class Binary(op: Bop, e1: Expr, e2: Expr) extends Expr
 
   /** Unary operators ''uop''. */
@@ -23,3 +20,57 @@ package jsy {
   trait Bop
 
 }
+
+/** Defining the JavaScripty language platform.
+  *
+  * ==Design Principles==
+  *
+  * JavaScripty is defined through a number of sub-language packages to
+  * facilitate instantiations that contain only particular sub-languages.
+  *
+  * The sub-languages are organized so that we can design experimental
+  * program analyses incrementally on small, well-defined sub-languages.
+  *
+  * This goal does come with a cost: the language platform is more complex
+  * from abstract syntax representation to parsing to interpreting.
+  *
+  * We pose some design principles:
+  *
+  *   - To try to limit excessive generalization, we do not aim to support
+  * any combination of language modules. We focus on commonly-used
+  * sub-languages (e.g., numerical constraints, a core λ-calculus,
+  * a core first-order imperative language).
+  *   - We limit the syntactic stratification and say that programs are
+  * simply expressions and all language constructs are expressions.
+  *   - We emphasize as simple and clean semantics as possible (with
+  * static typing).
+  *   - For convenience in writing programs, we aim to be compatible
+  * with concrete syntax of JavaScript, but we do not aim for
+  * semantic compatibility.
+  *
+  * ==This Package==
+  *
+  * This top-level package defines the abstract syntax nodes that
+  * are common to many sub-languages.
+  *
+  * ==Abstract Syntax==
+  *
+  * As a notation convenience, we write productions with concrete and
+  * abstract syntax using ϵ at the meta-level to separate concrete and
+  * abstract syntax.
+  *
+  *   - ''e'' ϵ `Expr` ::= ''v''
+  *     | $jsyUnaryProduction
+  *     | $jsyBinaryProduction
+  *   - ''uop'' ϵ `Uop`
+  *   - ''bop'' ϵ `Bop`
+  *   - ''v'' ϵ `Val`
+  *
+  * @define jsyUnaryProduction ''uop'' ''e,,1,,'' ϵ `Unary(''uop'', ''e,,1,,'')`
+  * @define jsyBinaryProduction ''e,,1,,'' ''bop'' ''e,,2,,'' ϵ `Binary(''bop'', ''e,,1,,'', ''e,,2,,'')`
+  *
+  * @author Bor-Yuh Evan Chang
+  */
+package object jsy
+
+

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/package.scala
@@ -19,6 +19,9 @@ package jsy {
   /** Binary operators ''bop''. */
   trait Bop
 
+  /** Values ''v'' with ''e'' ::= ''v''. */
+  trait Val extends Expr
+
 }
 
 /** Defining the JavaScripty language platform.

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/boolean/BooleanParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/boolean/BooleanParserSpec.scala
@@ -30,11 +30,33 @@ class BooleanParserSpec extends FlatSpec with Matchers with PropertyChecks {
         B(true),
         Binary(And, B(false), B(true))
       )
+    },
+    "true ? false : true" -> {
+      If(B(true), B(false), B(true))
+    },
+    "if (true) { false } else { true }" -> {
+      If(B(true), B(false), B(true))
+    }
+  )
+
+  val flexibles = Table(
+    "concrete" -> "abstract",
+    "if (true) false else true" -> {
+      If(B(true), B(false), B(true))
+    },
+    "if (true) false else if (true) false else true" -> {
+      If(B(true), B(false), If(B(true), B(false), B(true)))
     }
   )
 
   forAll (positives) { (conc, abs) =>
     it should s"parse $conc into $abs" in {
+      parse(conc) shouldEqual abs
+    }
+  }
+
+  forAll (flexibles) { (conc, abs) =>
+    it should s"flexibly parse $conc into $abs" in {
       parse(conc) shouldEqual abs
     }
   }


### PR DESCRIPTION
This PR is to add the missing if-then-else to the parsing of boolean expressions.

@bennostein @kyleheadley I had this implemented a week ago but didn't get a chance to push until now. I had accidentally worked on this on top of the interpreter stuff and wanted to separate it, so hopefully I didn't mess things up with the local rebasing.

Let's merge this one before #14. So could you please put priority on reviewing this one?