### PR TITLE
Extend JavaScripty to support all primitives and binding

### DIFF
--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/Denotational.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/Denotational.scala
@@ -25,7 +25,7 @@ object Denotational {
     type V = W
     import eval.{toOps,represent}
 
-    val fun: FixFun[Expr, V] = FixFun(rec => {
+    override lazy val fun: FixFun[Expr, V] = FixFun(rec => {
       case N(n) => n
       case Unary(Neg, e1) => - rec(e1)
       case Binary(Plus, e1, e2) => rec(e1) + rec(e2)

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/arithmetic/Parser.scala
@@ -21,6 +21,7 @@ import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpPa
   * @define arithmeticOpatom ''opatom'' ::= ''float''
   * @define arithmeticUop ''uop'' ::= '-'
   * @define arithmeticBop ''bop'' ::= '+' | '-' | '*' | '/'
+  *
   * @author Bor-Yuh Evan Chang
   */
 trait ParserLike extends OpParserLike with JsyParserLike {
@@ -46,6 +47,10 @@ trait ParserLike extends OpParserLike with JsyParserLike {
       List("*" -> Times, "/" -> Div)
       /* highest */
   )
+
+  override def start: Parser[Expr] = expr
+  override def expr: Parser[Expr] = binary
+  override lazy val bop: OpPrecedence = arithmeticBop
 }
 
 /** The parser for just this arithmetic sub-language.
@@ -53,10 +58,4 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   * @see [[ParserLike]]
   * @author Bor-Yuh Evan Chang
   */
-object Parser extends UnitOpParser with ParserLike {
-  override def start: Parser[Expr] = expr
-  override def expr: Parser[Expr] = binary
-
-  /** Define precedence of left-associative binary operators. */
-  override lazy val bop: OpPrecedence = arithmeticBop
-}
+object Parser extends UnitOpParser with ParserLike

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/binding/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/binding/Parser.scala
@@ -38,8 +38,7 @@ trait ParserLike extends OpParserLike with JsyParserLike {
 
   abstract override def opatom: Parser[Expr] =
     positioned {
-      "undefined" ^^^ Unit |
-      ident ^^ Var
+      "undefined" ^^^ Unit
     } |
     block |
     super.opatom

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/binding/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/binding/Parser.scala
@@ -43,7 +43,16 @@ trait ParserLike extends OpParserLike with JsyParserLike {
     block |
     super.opatom
 
-  lazy val bindingBop: OpPrecedence = List(List("," -> Seq))
+  lazy val seqBop: OpPrecedence = List(List("," -> Seq))
+
+  /** Parameter: define the non-terminal for the sub-expressions of sequencing expressions. */
+  def seqsub: Parser[Expr]
+
+  /** ''seq'' ::= ''seqsub,,1,,'' `,` ''seqsub,,2,,'' */
+  def seq: Parser[Expr] = binaryLeft(seqBop, seqsub)
+
+  override def start: Parser[Expr] = stmt
+  override def expr: Parser[Expr] = seq
 }
 
 object ParserLike {
@@ -70,7 +79,6 @@ object ParserLike {
 
 /** The parser for just bindings. */
 object Parser extends UnitOpParser with ParserLike {
-  override def start: Parser[Expr] = stmt
-  override def expr: Parser[Expr] = binary
-  override lazy val bop: OpPrecedence = bindingBop
+  override lazy val bop: OpPrecedence = Nil
+  override def seqsub: Parser[Expr] = binary
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/binding/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/binding/package.scala
@@ -5,13 +5,7 @@ package binding {
   /** @group Abstract Syntax Nodes */
   case object Unit extends Val
 
-  /** A Var node in an expression is a variable use.
-    *
-    * The name of the variable is stored privately.
-    *
-    * @group Abstract Syntax Nodes
-    */
-  case class Var(private val x: String) extends Expr
+
 
   /** Let-binding.
     *

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/boolean/Parser.scala
@@ -71,6 +71,10 @@ trait ParserLike extends OpParserLike with JsyParserLike {
     List("&&" -> And)
     /* highest */
   )
+
+  override def start: Parser[Expr] = expr
+  override def expr: Parser[Expr] = iteop
+  override lazy val bop: OpPrecedence = booleanBop
 }
 
 /** The parser for just this boolean sub-language.
@@ -79,8 +83,5 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   * @author Bor-Yuh Evan Chang
   */
 object Parser extends UnitOpParser with ParserLike {
-  override def start: Parser[Expr] = expr
-  override def expr: Parser[Expr] = iteop
   override def itesub: Parser[Expr] = iteop
-  override lazy val bop: OpPrecedence = booleanBop
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/OpParserLike.scala
@@ -3,7 +3,7 @@ package edu.colorado.plv.cuanto.jsy.common
 import edu.colorado.plv.cuanto.jsy._
 import edu.colorado.plv.cuanto.parsing.RichParsers
 
-import scala.util.parsing.combinator.RegexParsers
+import scala.util.parsing.combinator.JavaTokenParsers
 
 /** Parser components that handle unary and binary operators.
   *
@@ -60,7 +60,7 @@ import scala.util.parsing.combinator.RegexParsers
   *
   * @author Bor-Yuh Evan Chang
   */
-trait OpParserLike extends RegexParsers with RichParsers {
+trait OpParserLike extends JavaTokenParsers with RichParsers {
 
   /** Parameter: define expressions. */
   def expr: Parser[Expr]
@@ -124,6 +124,7 @@ trait OpParserLike extends RegexParsers with RichParsers {
     */
   def atom: Parser[Expr] =
     opatom |
+    positioned(ident ^^ Var) |
     parenthesized |
     block |
     failure("expected an atom")

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/common/UnitOpParser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/common/UnitOpParser.scala
@@ -9,7 +9,7 @@ import scala.util.parsing.combinator.{Parsers, RegexParsers}
   *
   * @author Bor-Yuh Evan Chang
   */
-trait UnitOpParser extends OpParserLike { _: RichParsers with RegexParsers with Parsers =>
+trait UnitOpParser extends OpParserLike {
   override def opatom: Parser[Expr] = failure("expected opatom")
   override def uop: Parser[Uop] = failure("expected uop")
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/Parser.scala
@@ -1,37 +1,41 @@
 package edu.colorado.plv.cuanto.jsy
 package numerical
 
-import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpParser}
+import edu.colorado.plv.cuanto.jsy.common.UnitOpParser
 
 /** Extend with the numerical sub-language.
+  *
+  * Mixes the [[arithmetic.ParserLike]] sub-language with the
+  * [[boolean.ParserLike]] sub-language with comparison operators.
   *
   * The numerical sub-language simply adds comparison operators:
   * `===`, `!==`, `<=`, `<`, `>=`, and `>`.
   *
   * @author Bor-Yuh Evan Chang
   */
-trait ParserLike extends OpParserLike with JsyParserLike {
+trait ParserLike extends boolean.ParserLike with arithmetic.ParserLike {
   lazy val comparisonBop: OpPrecedence = List(
     /* lowest */
     List("===" -> Eq, "!==" -> Ne),
     List("<=" -> Le, "<" -> Lt, ">=" -> Ge, ">" -> Gt)
     /* highest */
   )
-}
 
-/** The parser for just this numerical sub-language.
-  *
-  * Mixes the [[arithmetic.ParserLike]] sub-language with the
-  * [[boolean.ParserLike]] sub-language with comparison operators.
-  *
-  * @author Bor-Yuh Evan Chang
-  */
-object Parser extends UnitOpParser with ParserLike with boolean.ParserLike with arithmetic.ParserLike {
-  override def start: Parser[Expr] = expr
-  override def expr: Parser[Expr] = iteop
-  override def itesub: Parser[Expr] = expr
   override lazy val bop: OpPrecedence =
     /* lowest */
     booleanBop ++ (comparisonBop ++ arithmeticBop)
     /* highest */
+
+  override def start: Parser[Expr] = expr
+  override def expr: Parser[Expr] = iteop
+  override def itesub: Parser[Expr] = iteop
 }
+
+/** The parser for just this numerical sub-language.
+  *
+  * @author Bor-Yuh Evan Chang
+  */
+object Parser extends UnitOpParser with ParserLike
+
+
+

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/ParserWithBinding.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/ParserWithBinding.scala
@@ -1,0 +1,16 @@
+package edu.colorado.plv.cuanto.jsy
+package numerical
+
+import edu.colorado.plv.cuanto.jsy.common.UnitOpParser
+
+/**
+  * @author Bor-Yuh Evan Chang
+  */
+trait ParserWithBindingLike extends ParserLike with binding.ParserLike {
+  override def seqsub: Parser[Expr] = iteop
+}
+
+/**
+  * @author Bor-Yuh Evan Chang
+  */
+object ParserWithBinding extends UnitOpParser with ParserWithBindingLike

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/numerical/package.scala
@@ -1,11 +1,5 @@
 package edu.colorado.plv.cuanto.jsy
 
-/** Define a sub-language of numerical constraints.
-  *
-  * Combines [[arithmetic]] and [[boolean]].
-  *
-  * @author Bor-Yuh Evan Chang
-  */
 package numerical {
 
   /** Equal ''bop'' ::= `==`. */
@@ -22,3 +16,11 @@ package numerical {
   case object Gt extends Bop
 
 }
+
+/** Define a sub-language of numerical constraints.
+  *
+  * Combines [[arithmetic]] and [[boolean]].
+  *
+  * @author Bor-Yuh Evan Chang
+  */
+package object numerical

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/package.scala
@@ -23,6 +23,13 @@ package jsy {
   /** Values ''v''. */
   trait Val extends Expr
 
+  /** Variables ''x''.
+    *
+    * A `Var` node in an expression is a variable use. The name of the
+    * variable is stored privately.
+    */
+  case class Var(private val x: String) extends Val
+
 }
 
 /** Defining the JavaScripty language platform.
@@ -68,7 +75,8 @@ package jsy {
   *     | $jsyBinaryProduction
   *   - ''uop'' ϵ `Uop`
   *   - ''bop'' ϵ `Bop`
-  *   - ''v'' ϵ `Val`
+  *   - ''v'' ϵ `Val` ::= ''x''
+  *   - ''x'' ϵ `Var`
   *
   * @define jsyUnaryProduction ''uop'' ''e,,1,,'' ≡ `Unary(''uop'', ''e,,1,,'')`
   * @define jsyBinaryProduction ''e,,1,,'' ''bop'' ''e,,2,,'' ≡ `Binary(''bop'', ''e,,1,,'', ''e,,2,,'')`

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/primitives/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/primitives/Parser.scala
@@ -1,0 +1,12 @@
+package edu.colorado.plv.cuanto.jsy
+package primitives
+
+import edu.colorado.plv.cuanto.jsy.common.UnitOpParser
+
+/** The parser for JavaScripty with primitive values.
+  *
+  * Mixes the [[numerical.ParserWithBindingLike]] sub-language with the [[string.ParserLike]] sub-language.
+  *
+  * @author Bor-Yuh Evan Chang
+  */
+object Parser extends UnitOpParser with string.ParserLike with numerical.ParserWithBindingLike

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/string/Parser.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/string/Parser.scala
@@ -5,20 +5,17 @@ import edu.colorado.plv.cuanto.jsy.common.{JsyParserLike, OpParserLike, UnitOpPa
 
 /** Parse into the string sub-language.
   *
+  * Relies on [[edu.colorado.plv.cuanto.jsy.common.OpParserLike]] to parse unary and binary expressions.
+  *
   * @author Kyle Headley
   */
 trait ParserLike extends OpParserLike with JsyParserLike {
-  /** ''opatom'' ::= ''"string"'' */
   abstract override def opatom: Parser[Expr] =
     positioned {
-      stringLiteral ^^ (s => S(s.substring(1, s.length()-1)))
+      stringLiteral ^^ { s => S(s.substring(1, s.length - 1)) }
     } |
     super.opatom
 
-  /** Precedence: { '+' }
-    *
-    * ''bop'' ::= '+'
-    */
   lazy val stringBop: OpPrecedence = List(
       /* lowest */
       List("+" -> Concat)
@@ -26,11 +23,13 @@ trait ParserLike extends OpParserLike with JsyParserLike {
   )
 }
 
-/** The parser for just this string sub-language. */
+/** The parser for just this string sub-language.
+  *
+  * @see [[ParserLike]]
+  * @author Kyle Headley
+  */
 object Parser extends UnitOpParser with ParserLike {
   override def start: Parser[Expr] = expr
   override def expr: Parser[Expr] = binary
-
-  /** Define precedence of left-associative binary operators. */
   override lazy val bop: OpPrecedence = stringBop
 }

--- a/src/main/scala/edu/colorado/plv/cuanto/jsy/string/package.scala
+++ b/src/main/scala/edu/colorado/plv/cuanto/jsy/string/package.scala
@@ -1,37 +1,22 @@
 package edu.colorado.plv.cuanto.jsy
 
-/** Define an string sub-language.
-  *
-  * @author Kyle Headley
-  */
 package string {
 
-  /* Literals and values. */
-
-  /** Strings ''e'' ::= ''"s"''. */
+  /** Strings ''e'' ::= `"` ''s'' `"`. */
   case class S(s: String) extends Expr
-
-  /* Binary operators. */
-
-  /** Plus ''bop'' ::= `+`. */
-  case object Concat extends Bop
 
 }
 
+/** Define a string sub-language.
+  *
+  * @author Kyle Headley
+  * @author Bor-Yuh Evan Chang
+  */
 package object string {
 
-  /** Define string. */
-  def isValue(e: Expr): Boolean = e match {
-    case S(_) => true
-    case _ => false
-  }
-
-  /** Define extractor for strings. */
-  object Value {
-    def unapply(e: Expr): Option[Expr] = e match {
-      case S(_) => Some(e)
-      case _ => None
-    }
-  }
+  /** The string concatenation operator is syntactically overloaded as
+    * [[edu.colorado.plv.cuanto.jsy.arithmetic.Plus]].
+    */
+  val Concat: Bop = arithmetic.Plus
 
 }

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/arithmetic/ArithmeticParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/arithmetic/ArithmeticParserSpec.scala
@@ -1,13 +1,12 @@
 package edu.colorado.plv.cuanto.jsy
 package arithmetic
 
+import edu.colorado.plv.cuanto.CuantoSpec
 import edu.colorado.plv.cuanto.jsy.arithmetic.Parser.parse
+import edu.colorado.plv.cuanto.jsy.common.ParserBehaviors
 import edu.colorado.plv.cuanto.testing.implicits.tryEquality
-import org.scalacheck.Gen
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
 
-class ArithmeticParserSpec extends FlatSpec with Matchers with PropertyChecks {
+class ArithmeticParserSpec extends CuantoSpec with ParserBehaviors {
 
   "jsy.arithmetic.Parser" should "parse 3.14" in {
     parse("3.14") shouldEqual N(3.14)
@@ -19,7 +18,7 @@ class ArithmeticParserSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   }
 
-  val positives = Table(
+  override lazy val positives = Table(
     "concrete" -> "abstract",
     "x" -> Var("x"),
     "(3.14)" -> N(3.14),
@@ -31,34 +30,12 @@ class ArithmeticParserSpec extends FlatSpec with Matchers with PropertyChecks {
     "1 + 2 * 3" -> Binary(Plus, N(1), Binary(Times, N(2), N(3)))
   )
 
-  forAll (positives) { (conc, abs) =>
-    it should s"parse $conc into $abs" in {
-      parse(conc) shouldEqual abs
-    }
-  }
-
-  it should "parse floating-point literals" in {
-    forAll (Gen.posNum[Double]) { d =>
-      parse(d.toString) shouldEqual N(d)
-    }
-  }
-
-  it should "parse integer literals" in {
-    forAll (Gen.posNum[Int]) { i =>
-      parse(i.toString) shouldEqual N(i.toDouble)
-    }
-  }
-
-  val negatives = Table(
+  override lazy val negatives = Table(
     "concrete",
     "-",
     "-+*"
   )
 
-  forAll (negatives) { conc =>
-    it should s"not parse $conc" in {
-      parse(conc) should be a 'failure
-    }
-  }
+  it should behave like parser(parse)
 
 }

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/arithmetic/ArithmeticParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/arithmetic/ArithmeticParserSpec.scala
@@ -21,6 +21,7 @@ class ArithmeticParserSpec extends FlatSpec with Matchers with PropertyChecks {
 
   val positives = Table(
     "concrete" -> "abstract",
+    "x" -> Var("x"),
     "(3.14)" -> N(3.14),
     "1 + 1" -> Binary(Plus, N(1), N(1)),
     "1 - 1" -> Binary(Minus, N(1), N(1)),

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/binding/BindingParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/binding/BindingParserSpec.scala
@@ -1,20 +1,17 @@
 package edu.colorado.plv.cuanto.jsy
 package binding
 
+import edu.colorado.plv.cuanto.CuantoSpec
 import edu.colorado.plv.cuanto.jsy.binding.Parser.parse
-import edu.colorado.plv.cuanto.testing.implicits.tryEquality
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import edu.colorado.plv.cuanto.jsy.common.ParserBehaviors
 
 /**
   * @author Kyle Headley
   * @author Bor-Yuh Evan Chang
   */
-class BindingParserSpec extends FlatSpec with Matchers with PropertyChecks {
+class BindingParserSpec extends CuantoSpec with ParserBehaviors {
 
-  behavior of "jsy.binding.Parser"
-
-  val positives = Table(
+  override lazy val positives = Table(
     "concrete" -> "abstract",
     // expressions
     "x" -> Var("x"),
@@ -39,35 +36,19 @@ class BindingParserSpec extends FlatSpec with Matchers with PropertyChecks {
     "x; y" -> Binary(Seq, Var("x"), Var("y"))
   )
 
-  val flexibles = Table(
+  override lazy val flexibles = Table(
     "concrete" -> "abstract",
     "{ let x = y y }"
       -> Bind(Var("x"), Var("y"), Var("y"))
   )
 
-  val negatives = Table(
+  override lazy val negatives = Table(
     "concrete",
     "123abc",
     "(let x = y)",
     "(x; y)"
   )
 
-  forAll (positives) { (conc, abs) =>
-    it should s"parse $conc into $abs" in {
-      parse(conc) shouldEqual abs
-    }
-  }
-
-  forAll (flexibles) { (conc, abs) =>
-    it should s"flexibly parse $conc into $abs" in {
-      parse(conc) shouldEqual abs
-    }
-  }
-
-  forAll (negatives) { conc =>
-    it should s"not parse $conc" in {
-      parse(conc) should be a 'failure
-    }
-  }
+  "jsy.binding.Parser" should behave like parser(parse)
 
 }

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/boolean/BooleanParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/boolean/BooleanParserSpec.scala
@@ -1,7 +1,9 @@
 package edu.colorado.plv.cuanto.jsy
 package boolean
 
+import edu.colorado.plv.cuanto.CuantoSpec
 import edu.colorado.plv.cuanto.jsy.boolean.Parser.parse
+import edu.colorado.plv.cuanto.jsy.common.ParserBehaviors
 import edu.colorado.plv.cuanto.testing.implicits.tryEquality
 import org.scalatest.prop.PropertyChecks
 import org.scalatest.{FlatSpec, Matchers}
@@ -9,11 +11,9 @@ import org.scalatest.{FlatSpec, Matchers}
 /**
   * @author Bor-Yuh Evan Chang
   */
-class BooleanParserSpec extends FlatSpec with Matchers with PropertyChecks {
+class BooleanParserSpec extends CuantoSpec with ParserBehaviors {
 
-  behavior of "jsy.boolean.Parser"
-
-  val positives = Table(
+  override lazy val positives = Table(
     "concrete" -> "abstract",
     "true" -> B(true),
     "false" -> B(false),
@@ -39,7 +39,7 @@ class BooleanParserSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   )
 
-  val flexibles = Table(
+  override lazy val flexibles = Table(
     "concrete" -> "abstract",
     "if (true) false else true" -> {
       If(B(true), B(false), B(true))
@@ -49,16 +49,6 @@ class BooleanParserSpec extends FlatSpec with Matchers with PropertyChecks {
     }
   )
 
-  forAll (positives) { (conc, abs) =>
-    it should s"parse $conc into $abs" in {
-      parse(conc) shouldEqual abs
-    }
-  }
-
-  forAll (flexibles) { (conc, abs) =>
-    it should s"flexibly parse $conc into $abs" in {
-      parse(conc) shouldEqual abs
-    }
-  }
+  "jsy.boolean.Parser" should behave like parser(parse)
 
 }

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/boolean/BooleanParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/boolean/BooleanParserSpec.scala
@@ -4,9 +4,6 @@ package boolean
 import edu.colorado.plv.cuanto.CuantoSpec
 import edu.colorado.plv.cuanto.jsy.boolean.Parser.parse
 import edu.colorado.plv.cuanto.jsy.common.ParserBehaviors
-import edu.colorado.plv.cuanto.testing.implicits.tryEquality
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
 
 /**
   * @author Bor-Yuh Evan Chang

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/common/ParserBehaviors.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/common/ParserBehaviors.scala
@@ -1,0 +1,45 @@
+package edu.colorado.plv.cuanto
+package jsy
+package common
+
+import org.scalatest.prop.{TableFor1, TableFor2}
+
+import scala.util.Try
+
+/**
+  * @author Bor-Yuh Evan Chang
+  */
+trait ParserBehaviors { _: CuantoSpec =>
+
+  type PositiveTable = TableFor2[String,Expr]
+  type NegativeTable = TableFor1[String]
+
+  /** Parameter: specify the positive tests. */
+  lazy val positives: PositiveTable = Table("concrete" -> "abstract")
+
+  /** Parameter: specify the flexible tests. */
+  lazy val flexibles: PositiveTable = Table("concrete" -> "abstract")
+
+  /** Parameter: specify the negative tests. */
+  lazy val negatives: NegativeTable = Table("concrete")
+
+  def parser(parse: String => Try[Expr]): Unit = {
+    import testing.implicits.tryEquality
+    forAll(positives) { (conc, abs) =>
+      it should s"parse $conc into $abs" in {
+        parse(conc) shouldEqual abs
+      }
+    }
+    forAll(flexibles) { (conc, abs) =>
+      it should s"flexibly parse $conc into $abs" in {
+        parse(conc) shouldEqual abs
+      }
+    }
+    forAll(negatives) { conc =>
+      it should s"not parse $conc" in {
+        parse(conc) should be a 'failure
+      }
+    }
+  }
+
+}

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/numerical/NumericalParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/numerical/NumericalParserSpec.scala
@@ -1,21 +1,18 @@
 package edu.colorado.plv.cuanto.jsy
 package numerical
 
+import edu.colorado.plv.cuanto.CuantoSpec
 import edu.colorado.plv.cuanto.jsy.arithmetic._
 import edu.colorado.plv.cuanto.jsy.boolean._
+import edu.colorado.plv.cuanto.jsy.common.ParserBehaviors
 import edu.colorado.plv.cuanto.jsy.numerical.Parser.parse
-import edu.colorado.plv.cuanto.testing.implicits.tryEquality
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
 
 /**
   * @author Bor-Yuh Evan Chang
   */
-class NumericalParserSpec extends FlatSpec with Matchers with PropertyChecks {
+class NumericalParserSpec extends CuantoSpec with ParserBehaviors {
 
-  behavior of "jsy.numerical.Parser"
-
-  val positives = Table(
+  override lazy val positives = Table(
     "concrete" -> "abstract",
     /* constraints */
     "true !== false" -> Binary(Ne, B(true), B(false)),
@@ -28,10 +25,6 @@ class NumericalParserSpec extends FlatSpec with Matchers with PropertyChecks {
     "true !== 4 < 5" -> Binary(Ne, B(true), Binary(Lt, N(4), N(5)))
   )
 
-  forAll (positives) { (conc, abs) =>
-    it should s"parse $conc into $abs" in {
-      parse(conc) shouldEqual abs
-    }
-  }
+  "jsy.numerical.Parser" should behave like parser(parse)
 
 }

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/primitives/PrimitivesParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/primitives/PrimitivesParserSpec.scala
@@ -4,18 +4,16 @@ package primitives
 import edu.colorado.plv.cuanto.CuantoSpec
 import edu.colorado.plv.cuanto.jsy.arithmetic._
 import edu.colorado.plv.cuanto.jsy.binding._
-import edu.colorado.plv.cuanto.jsy.string._
+import edu.colorado.plv.cuanto.jsy.common.ParserBehaviors
 import edu.colorado.plv.cuanto.jsy.primitives.Parser.parse
-import edu.colorado.plv.cuanto.testing.implicits.tryEquality
+import edu.colorado.plv.cuanto.jsy.string._
 
 /**
   * @author Bor-Yuh Evan Chang
   */
-class PrimitivesParserSpec extends CuantoSpec {
+class PrimitivesParserSpec extends CuantoSpec with ParserBehaviors {
 
-  behavior of "jsy.primitives.Parser"
-
-  val positives = Table(
+  override lazy val positives = Table(
     "concrete" -> "abstract",
     """{ let x = 3
       |  let y = "abc"
@@ -24,10 +22,6 @@ class PrimitivesParserSpec extends CuantoSpec {
       -> Bind(Var("x"), N(3), Bind(Var("y"), S("abc"), Binary(Plus, Var("x"), Var("y"))))
   )
 
-  forAll (positives) { (conc, abs) =>
-    it should s"parse $conc into $abs" in {
-      parse(conc) shouldEqual abs
-    }
-  }
+  "jsy.primitives.Parser" should behave like parser(parse)
 
 }

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/primitives/PrimitivesParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/primitives/PrimitivesParserSpec.scala
@@ -1,0 +1,33 @@
+package edu.colorado.plv.cuanto.jsy
+package primitives
+
+import edu.colorado.plv.cuanto.CuantoSpec
+import edu.colorado.plv.cuanto.jsy.arithmetic._
+import edu.colorado.plv.cuanto.jsy.binding._
+import edu.colorado.plv.cuanto.jsy.string._
+import edu.colorado.plv.cuanto.jsy.primitives.Parser.parse
+import edu.colorado.plv.cuanto.testing.implicits.tryEquality
+
+/**
+  * @author Bor-Yuh Evan Chang
+  */
+class PrimitivesParserSpec extends CuantoSpec {
+
+  behavior of "jsy.primitives.Parser"
+
+  val positives = Table(
+    "concrete" -> "abstract",
+    """{ let x = 3
+      |  let y = "abc"
+      |  x + y }
+    """.stripMargin
+      -> Bind(Var("x"), N(3), Bind(Var("y"), S("abc"), Binary(Plus, Var("x"), Var("y"))))
+  )
+
+  forAll (positives) { (conc, abs) =>
+    it should s"parse $conc into $abs" in {
+      parse(conc) shouldEqual abs
+    }
+  }
+
+}

--- a/src/test/scala/edu/colorado/plv/cuanto/jsy/string/StringParserSpec.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/jsy/string/StringParserSpec.scala
@@ -1,31 +1,22 @@
 package edu.colorado.plv.cuanto.jsy
 package string
 
+import edu.colorado.plv.cuanto.CuantoSpec
+import edu.colorado.plv.cuanto.jsy.common.ParserBehaviors
 import edu.colorado.plv.cuanto.jsy.string.Parser.parse
-import edu.colorado.plv.cuanto.testing.implicits.tryEquality
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
 
 /**
   * @author Kyle Headley
   */
-class StringParserSpec extends FlatSpec with Matchers with PropertyChecks {
+class StringParserSpec extends CuantoSpec with ParserBehaviors {
 
-  behavior of "jsy.string.Parser"
-
-  val positives = Table(
+  override lazy val positives = Table(
     "concrete" -> "abstract",
     "\"hello\"" -> S("hello"),
     "\"world\"" -> S("world"),
     "\"one\" + \"one\"" -> Binary(Concat,S("one"),S("one"))
   )
 
-
-
-  forAll (positives) { (conc, abs) =>
-    it should s"parse $conc into $abs" in {
-      parse(conc) shouldEqual abs
-    }
-  }
+  "jsy.string.Parser" should behave like parser(parse)
 
 }


### PR DESCRIPTION
The net result of this feature is a JavaScripty language with all primitive values (numbers, booleans, strings) with variable binding.

@kyleheadley @bennostein There are probably parts that could documented better. Please take a look and let me know.