### PR TITLE
Add Scala SMT-LIB dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,15 @@ scala:
 - 2.12.1
 jdk:
 - oraclejdk8
+addons:
+  apt:
+    sources:
+    # This package repo is necessary for getting z3 on Ubuntu 14.04
+    - sourceline: 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_14.04/ /'
+      key_url: 'http://download.opensuse.org/repositories/home:delcypher:z3/xUbuntu_14.04/Release.key'
+    packages:
+    # Install z3 for use in tests using scala-smtlib
+    - z3
 script:
 - sbt clean coverage test
 after_success:

--- a/build.sbt
+++ b/build.sbt
@@ -67,6 +67,10 @@ lazy val root = (project in file(".")).
     // Wala dependency
     libraryDependencies ++= walaCore,
 
+    // scala-smtlib comes from the "sonatype releases" repository
+    resolvers += sonatypeResolver,
+    libraryDependencies += scalaSMTLIB,
+
     // Name
     name := "cuanto"
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,4 +19,7 @@ object Dependencies {
     "com.ibm.wala" % "com.ibm.wala.util" % "1.4.2",
     "com.ibm.wala" % "com.ibm.wala.core" % "1.4.2"
   )
+
+  lazy val sonatypeResolver = "Sonatype OSS Releases" at "https://oss.sonatype.org/content/repositories/releases"
+  lazy val scalaSMTLIB = "com.regblanc" %% "scala-smtlib" % "0.2.1"
 }

--- a/src/test/scala/edu/colorado/plv/cuanto/example/ScalaSmtlibExample.scala
+++ b/src/test/scala/edu/colorado/plv/cuanto/example/ScalaSmtlibExample.scala
@@ -1,0 +1,125 @@
+package edu.colorado.plv.cuanto
+
+package example
+
+import org.scalatest.tagobjects.Slow
+
+import smtlib.Interpreter
+import smtlib.interpreters.Z3Interpreter
+import smtlib.parser.Commands.{
+  Assert,
+  CheckSat,
+  Command,
+  DeclareConst,
+  DefineFun,
+  FunDef,
+  GetModel,
+  Pop,
+  Push
+}
+import smtlib.parser.CommandsResponses.{
+  CheckSatStatus,
+  Error,
+  GetModelResponseSuccess,
+  SatStatus,
+  Success,
+  UnsatStatus
+}
+import smtlib.parser.Terms.{
+  QualifiedIdentifier,
+  SimpleIdentifier,
+  SSymbol,
+  Term
+}
+import smtlib.theories.Core.{
+  And,
+  False,
+  Not,
+  Or,
+  True
+}
+import smtlib.theories.Ints.{
+  IntSort,
+  LessThan,
+  GreaterEquals,
+  GreaterThan,
+  Neg,
+  NumeralLit
+}
+
+/** Usage examples based on the scala-smtlib integration tests
+  *
+  * [[https://github.com/regb/scala-smtlib/blob/v0.2.1/src/it/scala/smtlib/it/SmtLibRunnerTests.scala]]
+  *
+  * @author octalsrc
+  */
+class ScalaSmtlibExample extends CuantoSpec {
+
+  "Evaluating SMT scripts" should "go like this" taggedAs(Slow) in {
+    forAll (testCmds) { (cmd,res) => z3.eval(cmd) should equal (res) }
+  }
+
+  lazy val z3: Interpreter = Z3Interpreter.buildDefault
+
+  val zero: Term = NumeralLit(0)
+  val one: Term = NumeralLit(1)
+  val three: Term = NumeralLit(3)
+
+  val mkVar: SSymbol => Term = name =>
+  QualifiedIdentifier(SimpleIdentifier(name))
+
+  val xs: SSymbol = SSymbol("x")
+  val ys: SSymbol = SSymbol("y")
+  val x: Term = mkVar(xs)
+  val y: Term = mkVar(ys)
+
+  val goodExpr: Term =
+    And(
+      GreaterEquals(x,zero),
+      Not(GreaterThan(x,three)),
+      LessThan(y,x)
+    )
+
+  /** Models are returned as sequences of "define-fun" commands */
+  val goodModel: List[Command] = List(
+    DefineFun(FunDef(ys, List.empty, IntSort(), Neg(one))),
+    DefineFun(FunDef(xs, List.empty, IntSort(), zero))
+  )
+
+  val badExpr: Term =
+    And(
+      GreaterEquals(x,three),
+      LessThan(x,zero)
+    )
+
+  /** This is an example SMT script (as a sequence of commands, which
+    * are given to the interpreter one by one)
+    *
+    * On the left is the command, and on the right is the response
+    * that is received.
+    */
+  val testCmds = Table(
+    "command" -> "response",
+
+    Push(0) -> Success,
+    Assert(Or(True(),False())) -> Success,
+    CheckSat() -> CheckSatStatus(SatStatus),
+    Pop(0) -> Success,
+
+    DeclareConst(xs,IntSort()) -> Success,
+    DeclareConst(ys,IntSort()) -> Success,
+
+    Push(0) -> Success,
+    Assert(goodExpr) -> Success,
+    CheckSat() -> CheckSatStatus(SatStatus),
+    GetModel() -> GetModelResponseSuccess(goodModel),
+    Pop(0) -> Success,
+
+    Push(0) -> Success,
+    Assert(badExpr) -> Success,
+    CheckSat() -> CheckSatStatus(UnsatStatus),
+    GetModel() -> Error("line 31 column 10: model is not available"),
+    Pop(0) -> Success
+  )
+
+}


### PR DESCRIPTION
This PR adds EPFL-LARA's [`scala-smtlib`-`v0.2.1`](https://github.com/regb/scala-smtlib) to our project's dependencies and provides a [ScalaTest suite](https://github.com/cuplv/cuanto/blob/4fcedbdaa686209d6d61ecac48d7652e07c20e30/src/test/scala/edu/colorado/plv/cuanto/example/ScalaSmtlibExample.scala) that verifies it works and demonstrates how to construct SMT scripts and call the solver.