### PR TITLE
Reproducible development environment with Nix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,11 @@
-language: scala
-scala:
-- 2.12.1
-jdk:
-- oraclejdk8
-addons:
-  apt:
-    sources:
-    # This package repo is necessary for getting z3 on Ubuntu 14.04
-    - sourceline: 'deb http://download.opensuse.org/repositories/home:/delcypher:/z3/xUbuntu_14.04/ /'
-      key_url: 'http://download.opensuse.org/repositories/home:delcypher:z3/xUbuntu_14.04/Release.key'
-    packages:
-    # Install z3 for use in tests using scala-smtlib
-    - z3
+language: nix
+before_script:
+- cd $HOME && git clone https://github.com/cuplv/cuplv-nixpkgs && cuplv-nixpkgs/install && cd -
+- nix-env -iA nixpkgs.bashInteractive
 script:
-- sbt clean coverage test
+- nix-shell --command "sbt clean coverage test"
 after_success:
-- sbt coverageReport coveralls codacyCoverage
+- nix-shell --command "sbt coverageReport coveralls codacyCoverage"
 before_deploy:
 # Record minimal build information via the Git user ident
 - git config --global user.name "$USER"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: nix
 before_script:
-- cd $HOME && git clone https://github.com/cuplv/cuplv-nixpkgs && cuplv-nixpkgs/install && cd -
+- mkdir -p $HOME/overlays && cd $HOME/overlays && git clone https://github.com/cuplv/cuplv-nixpkgs && cd -
 - nix-env -iA nixpkgs.bashInteractive
 script:
-- nix-shell --command "sbt clean coverage test"
+- nix-shell --command "sbt clean coverage test" -I nixpkgs-overlays=$HOME/overlays
 after_success:
-- nix-shell --command "sbt coverageReport coveralls codacyCoverage"
+- nix-shell --command "sbt coverageReport coveralls codacyCoverage" -I nixpkgs-overlays=$HOME/overlays
 before_deploy:
 # Record minimal build information via the Git user ident
 - git config --global user.name "$USER"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ before_script:
 - mkdir -p $HOME/overlays && cd $HOME/overlays && git clone https://github.com/cuplv/cuplv-nixpkgs && cd -
 - nix-env -iA nixpkgs.bashInteractive
 script:
-- nix-shell --command "sbt clean coverage test" -I nixpkgs-overlays=$HOME/overlays
+- nix-shell --pure --command "sbt clean coverage test" -I nixpkgs-overlays=$HOME/overlays
 after_success:
-- nix-shell --command "sbt coverageReport coveralls codacyCoverage" -I nixpkgs-overlays=$HOME/overlays
+- nix-shell --pure --command "sbt coverageReport coveralls codacyCoverage" -I nixpkgs-overlays=$HOME/overlays
 before_deploy:
 # Record minimal build information via the Git user ident
 - git config --global user.name "$USER"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,17 +38,46 @@ We use Scaladoc and follow the standard guidelines from [Scaladoc for Library Au
 
 ## Development Environment
 
-### Dependencies
+### Getting an environment with `nix-shell`
+
+The simplest way to set up the build environment if you are running
+Linux, MacOS, or Windows (with a Linux subsystem) is with
+the [Nix package manager](http://nixos.org/nix/).  With the Nix
+package manager installed (see [Nix project](http://nixos.org/nix/)),
+add the [`cuplv-nixpkgs`](https://github.com/cuplv/cuplv-nixpkgs)
+overlay and then use `nix-shell` to open a shell with all dependencies
+available.
+
+    # Add the cuplv-nixpkgs overlay
+    $ git clone https://github.com/cuplv/cuplv-nixpkgs
+    $ cuplv-nixpkgs/install
+    
+    # Clone the cuanto project
+    $ git clone https://github.com/cuplv/cuanto
+    
+    # Enter the cuanto build environment
+    $ cd cuanto
+    $ nix-shell
+    
+    # Test the build environment
+    [nix-shell:~/cuanto]$ sbt test
+
+### Manually setting up an environment
+
+If you would like to set up a build environment using your own package
+manager, you will need to find and install the following tools:
 
 - JDK 8
 - `sbt`
+- `z3`
 
-#### macOS: Install Dependencies
+### Setting up an environment with on MacOS with Homebrew
 
 Using [Homebrew](https://brew.sh/), install dependencies as follows:
 ```
 $ brew cask install java
 $ brew install sbt
+$ brew install z3
 ```
 
 ### Building and Testing 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,7 +71,7 @@ manager, you will need to find and install the following tools:
 - `sbt`
 - `z3`
 
-### Setting up an environment with on MacOS with Homebrew
+### Setting up an environment on MacOS with Homebrew
 
 Using [Homebrew](https://brew.sh/), install dependencies as follows:
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -4,6 +4,8 @@ import SystemClasspath._
 enablePlugins(SiteScaladocPlugin)
 enablePlugins(GhpagesPlugin)
 
+val cuantoClasspath = systemClasspath("CUANTO_CLASSPATH")
+
 lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
@@ -72,11 +74,11 @@ lazy val root = (project in file(".")).
     resolvers += sonatypeResolver,
     libraryDependencies += scalaSMTLIB,
 
-    // Tell sbt to look at $CLASSPATH for unmanaged jars.  This is
-    // where system-installed jars (such as jars that depend on native
-    // libraries) are usually found.
-    unmanagedClasspath in Compile ++= systemClasspath,
-    unmanagedClasspath in Test ++= systemClasspath,
+    // Tell sbt to look at $CUANTO_CLASSPATH for unmanaged jars.  This
+    // is where system-installed jars (such as jars that depend on
+    // native libraries) are placed by the nix build.
+    unmanagedClasspath in Compile ++= cuantoClasspath,
+    unmanagedClasspath in Test ++= cuantoClasspath,
 
     // Name
     name := "cuanto"

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import Dependencies._
+import SystemClasspath._
 
 enablePlugins(SiteScaladocPlugin)
 enablePlugins(GhpagesPlugin)
@@ -70,6 +71,12 @@ lazy val root = (project in file(".")).
     // scala-smtlib comes from the "sonatype releases" repository
     resolvers += sonatypeResolver,
     libraryDependencies += scalaSMTLIB,
+
+    // Tell sbt to look at $CLASSPATH for unmanaged jars.  This is
+    // where system-installed jars (such as jars that depend on native
+    // libraries) are usually found.
+    unmanagedClasspath in Compile ++= systemClasspath,
+    unmanagedClasspath in Test ++= systemClasspath,
 
     // Name
     name := "cuanto"

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,8 @@
+{ stdenv, sbt, z3, japron, jdk }:
+
+stdenv.mkDerivation rec {
+  name = "cuanto-${version}";
+  version = "dev";
+  src = ./.;
+  buildInputs = [ sbt z3 japron jdk ];
+}

--- a/default.nix
+++ b/default.nix
@@ -3,9 +3,9 @@
 # If we're using Linux openjdk, there is an option that removes lots
 # of unneeded extra dependencies.
 let jdk' =
-      if stdenv.isDarwin
-      then jdk
-      else jdk.override {minimal = true;};
+      if stdenv.isLinux
+      then jdk.override {minimal = true;}
+      else jdk;
 
 in
 
@@ -13,5 +13,5 @@ stdenv.mkDerivation rec {
   name = "cuanto-${version}";
   version = "dev";
   src = ./.;
-  buildInputs = [ sbt z3 jdk ];
+  buildInputs = [ sbt z3 jdk' ];
 }

--- a/default.nix
+++ b/default.nix
@@ -1,11 +1,52 @@
 { stdenv, sbt, z3, jdk }:
 
+let
+
 # If we're using Linux openjdk, there is an option that removes lots
 # of unneeded extra dependencies.
-let jdk' =
-      if stdenv.isLinux
-      then jdk.override {minimal = true;}
-      else jdk;
+jdk' =
+  if stdenv.isLinux
+  then jdk.override {minimal = true;}
+  else jdk;
+
+jarsPath = varName: pkgs: stdenv.mkDerivation {
+  name = "jarsPath-${varName}";
+  src = ./.;
+  buildInputs = [jdk'] ++ pkgs;
+  propagatedBuildInputs = pkgs;
+
+  installPhase = ''
+    # Create CLASSPATH at build-time
+    mkdir $out
+    echo $CLASSPATH > $out/${varName}
+
+    # Export build-time CLASSPATH at run-time
+    mkdir -p $out/nix-support
+    cat <<EOF > $out/nix-support/setup-hook
+    export ${varName}=`cat $out/${varName}`
+    EOF
+  '';
+};
+
+# This function takes a list of packages and produces a new package
+# which sets $CUANTO_CLASSPATH to include the jars of all the input
+# packages.  In this project, `sbt` is configured to load external
+# unmanaged jars from $CUANTO_CLASSPATH only, so system-installed jars
+# must use this function to be found.
+#
+# Example usage:
+#     ...
+#     buildInputs = [
+#       sbt z3 (cuantoClasspath [japron])
+#     ];
+#     ...
+#
+# Note that the packages given to `cuantoClasspath` are *propagated*,
+# so in the above example, the non-classpath parts of `japron` are
+# available to outer build just as they would have if
+# `cuantoClasspath` was not used.  You don't have to repeat it in the
+# "top level" of `buildInputs`.
+cuantoClasspath = jarsPath "CUANTO_CLASSPATH";
 
 in
 
@@ -13,5 +54,7 @@ stdenv.mkDerivation rec {
   name = "cuanto-${version}";
   version = "dev";
   src = ./.;
-  buildInputs = [ sbt z3 jdk' ];
+  buildInputs = [
+    sbt z3
+  ];
 }

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
-{ stdenv, sbt, z3, japron, jdk }:
+{ stdenv, sbt, z3, jdk }:
 
 stdenv.mkDerivation rec {
   name = "cuanto-${version}";
   version = "dev";
   src = ./.;
-  buildInputs = [ sbt z3 japron jdk ];
+  buildInputs = [ sbt z3 (jdk.override {minimal = true;}) ];
 }

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,17 @@
 { stdenv, sbt, z3, jdk }:
 
+# If we're using Linux openjdk, there is an option that removes lots
+# of unneeded extra dependencies.
+let jdk' =
+      if stdenv.isDarwin
+      then jdk
+      else jdk.override {minimal = true;};
+
+in
+
 stdenv.mkDerivation rec {
   name = "cuanto-${version}";
   version = "dev";
   src = ./.;
-  buildInputs = [ sbt z3 (jdk.override {minimal = true;}) ];
+  buildInputs = [ sbt z3 jdk ];
 }

--- a/project/SystemClasspath.scala
+++ b/project/SystemClasspath.scala
@@ -1,0 +1,16 @@
+import sbt._
+
+object SystemClasspath {
+
+  private[this] val systemClasspathRaw =
+    sys.env.get("CLASSPATH") match {
+      case Some(path) => path
+      case _ => ""
+    }
+
+  private[this] val jars: Seq[File] =
+    systemClasspathRaw.split(':').map(file).toSeq
+
+  val systemClasspath = jars.classpath
+
+}

--- a/project/SystemClasspath.scala
+++ b/project/SystemClasspath.scala
@@ -2,15 +2,15 @@ import sbt._
 
 object SystemClasspath {
 
-  private[this] val systemClasspathRaw =
-    sys.env.get("CLASSPATH") match {
+  private[this] val systemClasspathRaw = (pathName: String) =>
+    sys.env.get(pathName) match {
       case Some(path) => path
       case _ => ""
     }
 
-  private[this] val jars: Seq[File] =
-    systemClasspathRaw.split(':').map(file).toSeq
+  private[this] val jars: String => Seq[File] = pathName => 
+    systemClasspathRaw(pathName).split(':').map(file).toSeq
 
-  val systemClasspath = jars.classpath
+  val systemClasspath = (pathName: String) => jars(pathName).classpath
 
 }

--- a/project/SystemClasspath.scala
+++ b/project/SystemClasspath.scala
@@ -8,7 +8,7 @@ object SystemClasspath {
       case _ => ""
     }
 
-  private[this] val jars: String => Seq[File] = pathName => 
+  private[this] val jars: String => Seq[File] = pathName =>
     systemClasspathRaw(pathName).split(':').map(file).toSeq
 
   val systemClasspath = (pathName: String) => jars(pathName).classpath

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,3 @@
+with import <nixpkgs> {};
+
+callPackage ./. {}


### PR DESCRIPTION
This adds a [`cuanto` Nix derivation](https://github.com/cuplv/cuanto/compare/dev-environment?expand=1#diff-5712e736e0de6ba170577f8472c398e9) which specifies `cuanto`'s external system-installed dependencies and allows quick entry into a complete development environment (as explained in [CONTRIBUTING.md](https://github.com/cuplv/cuanto/compare/dev-environment?expand=1#diff-6a3371457528722a734f3c51d9238c13)):

    # Clone the cuanto project
    $ git clone https://github.com/cuplv/cuanto
    
    # Enter the cuanto build environment
    $ cd cuanto
    $ nix-shell
    
    # Test the build environment
    [nix-shell:~/cuanto]$ sbt test

The `CONTRIBUTING.md` doc also instructs you to add `cuplv-nixpkgs` to your Nix overlays.  This is not necessary for any of `cuanto`'s current dependencies, but is used by the `apron` branch currently under PR (for the `japron` package).  This overlay would be a convenient way for CUPLV researchers to quickly make their own projects available for integration into `cuanto` in the future.

## Usage: Adding new dependencies

To add a new dependency (with a package existing in either the main [`nixpkgs`](https://github.com/nixos/nixpkgs) or [`cuplv-nixpkgs`](https://github.com/cuplv/cuplv-nixpkgs), edit `default.nix`.  Add the package's name to the *derivation inputs* (the comma-separated list in curly braces at the top of the file) and to the *build inputs* (the space-separated list in square brackets assigned to `buildInputs`).

For an example of adding a dependency, see [this commit](https://github.com/cuplv/cuanto/commit/47c3e1e4cd3ce0e863df5b914d6cd7a7a11f324c) for setting up `japron`.

## Travis builds

Additionally, this PR modifies the Travis configuration so that our CI builds use the same environment.  This way, adding new dependencies to your development environment by editing `default.nix` adds them to the Travis build environment as well.

## System class-path for SBT

Finally, this PR configures SBT to search for unmanaged jars in `$CLASSPATH`, the standard environment variable which points to all system-installed java libraries (in particular this variable is set by `nix-shell` to point to all jars from the specified dependencies).  It is necessary to use system-installed jars when they depend on native libraries, as is the case for `japron`.